### PR TITLE
Refactor gitignore .idea/ files to simply be the .idea/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
 node_modules
-.idea/BrickBreaker.iml
-.idea/encodings.xml
-.idea/jsLibraryMappings.xml
-.idea/misc.xml
-.idea/modules.xml
-.idea/vcs.xml
-.idea/workspace.xml
+.idea


### PR DESCRIPTION
- IDE Configuration is typically excluded altogether in repositories as a best practice, so I went ahead and made sure no IntelliJ IDEA `.idea/` files would be included.
- removed all `.idea/*` lines from gitignore
- added `.idea` line to gitignore